### PR TITLE
ScatterAuction archetype

### DIFF
--- a/contracts/auctionable-archetype/RewardedAuction.sol
+++ b/contracts/auctionable-archetype/RewardedAuction.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+
+import "./ScatterAuction.sol";
+import "./tokens/IRewardToken.sol";
+
+contract RewardedAuction is ScatterAuction {
+
+	/**
+	 * @dev Amount of eth bidded by an address.
+	 */
+	mapping(address => uint256) public rewardTokenShares;
+
+	address public rewardToken;
+
+	function createBid(uint256 nftId) override public payable {
+		super.createBid(nftId);
+		rewardTokenShares[msg.sender] += msg.value;
+	}
+	
+	function claimRewardTokensBasedOnShares() public {
+		require(rewardToken != address(0), "No reward token for this auction.");
+		
+		IRewardToken token = IRewardToken(rewardToken);
+		token.mint(
+			msg.sender,
+			rewardTokenShares[msg.sender] * token.getRewardRatio()
+		);
+		rewardTokenShares[msg.sender] = 0;
+	}
+
+	function setRewardTokenAddress(address _rewardToken) public onlyOwner {
+		rewardToken = _rewardToken;
+	}
+}

--- a/contracts/auctionable-archetype/ScatterAuction.sol
+++ b/contracts/auctionable-archetype/ScatterAuction.sol
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: GPL-3.0
+// REMILIA COLLECTIVE
+// ETYMOLOGY: Zora Auction House -> Noun Auction House -> Bonkler Auction -> Scatter Auction
+
+pragma solidity ^0.8.4;
+
+import "solady/src/utils/SafeTransferLib.sol";
+import "solady/src/utils/SafeCastLib.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+contract ScatterAuction is OwnableUpgradeable {
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                           EVENTS                           */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  event AuctionCreated(uint256 indexed nftId, uint256 startTime, uint256 endTime);
+  event AuctionBid(uint256 indexed nftId, address bidder, uint256 amount, bool extended);
+  event AuctionExtended(uint256 indexed nftId, uint256 endTime);
+  event AuctionSettled(uint256 indexed nftId, address winner, uint256 amount);
+  event AuctionTimeBufferUpdated(uint256 timeBuffer);
+  event AuctionReservePriceUpdated(uint256 reservePrice);
+  event AuctionBidIncrementUpdated(uint256 bidIncrement);
+  event AuctionDurationUpdated(uint256 duration);
+
+  /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+  /*                          STORAGE                           */
+  /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+  /**
+   * @dev A struct containing the auction data and configuration.
+   * We bundle as much as possible into a single struct so that we can
+   * use a single view function to fetch all the relevant data,
+   * helping us reduce RPC calls.
+   *
+   * Notes:
+   *
+   * - `uint96` is enough to represent 79,228,162,514 ETH.
+   *   Currently, there is only 120,523,060 ETH in existence.
+   *
+   * - `uint40` is enough to represent timestamps up to year 36811 A.D.
+   */
+  struct AuctionData {
+		// The address of the current highest bid.
+    address bidder;
+		// The current highest bid amount.
+    uint96 amount;
+		// The start time of the auction.
+    uint40 startTime;
+		// The end time of the auction.
+    uint40 endTime;
+		// ERC721 token ID. Starts from 0.
+    uint24 nftId;
+		// ERC721 max supply.
+    uint24 maxSupply;
+    // Whether or not the auction has been settled.
+    bool settled;
+    // The ERC721 token contract.
+		// TODO refactor to "token"
+    address nftContract;
+    // The minimum price accepted in an auction.
+    uint96 reservePrice;
+    // The minimum bid increment.
+    uint96 bidIncrement;
+    // The duration of a single auction.
+    uint32 duration;
+    // The minimum amount of time left in an auction after a new bid is created.
+    uint32 timeBuffer;
+    // The amount of ETH in the NFT contract.
+    // This can be considered as the treasury balance.
+    uint256 nftContractBalance;
+  }
+
+	/**
+	* @dev The auction data.
+	*/
+	AuctionData internal _auctionData;
+
+	/**
+	* @dev The address that deployed the contract.
+	*/
+	address internal immutable _deployer;
+
+	/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+	/*                        CONSTRUCTOR                         */
+	/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+	constructor() {
+		_deployer = msg.sender;
+	}
+
+	/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+	/*                        INITIALIZER                         */
+	/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+	function initialize(
+		address nftContract,
+		uint24 maxSupply,
+		uint96 reservePrice,
+		uint96 bidIncrement,
+		uint32 duration,
+		uint32 timeBuffer
+	) external payable initializer {
+		require(_deployer == msg.sender, "Only the deployer can call.");
+		require(nftContract != address(0), "The nft token address can't be 0");
+		require(_auctionData.nftContract == address(0), "Already initialized.");
+		require(maxSupply > 0, "The token supply can't be 0");
+
+		__Ownable_init();
+
+		_checkReservePrice(reservePrice);
+		_checkBidIncrement(bidIncrement);
+		_checkDuration(duration);
+
+		_auctionData.nftContract = nftContract;
+		_auctionData.maxSupply = maxSupply;
+
+		_auctionData.reservePrice = reservePrice;
+		_auctionData.bidIncrement = bidIncrement;
+
+		_auctionData.duration = duration;
+		_auctionData.timeBuffer = timeBuffer;
+	}
+
+	/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+	/*              PUBLIC / EXTERNAL VIEW FUNCTIONS              */
+	/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+	/**
+	 * @dev Returns all the public data on the auction,
+	 * with some useful extra information on the NFT.
+	 */
+	function auctionData() external view returns (AuctionData memory data) {
+		data = _auctionData;
+		// Load some extra data regarding the NFT contract.
+		data.nftContractBalance = address(_auctionData.nftContract).balance;
+	}
+
+	/**
+	* @dev Returns whether the auction has ended.
+	*/
+	function hasEnded() public view returns (bool) {
+		return block.timestamp >= _auctionData.endTime;
+	}
+
+	/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+	/*              PUBLIC / EXTERNAL WRITE FUNCTIONS             */
+	/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+	/**
+	 * @dev Create a bid for a NFT, with a given amount.
+	 * This contract only accepts payment in ETH.
+	 *
+	 * The frontend should pass in the next `nftId` when the auction has ended.
+	 */
+	function createBid(uint256 nftId) public payable virtual {
+		// To prevent gas under-estimation.
+		require(gasleft() > 150000);
+
+		/* ------- AUTOMATIC AUCTION CREATION AND SETTLEMENT -------- */
+
+		bool creationFailed;
+		if (_auctionData.startTime == 0) {
+			// If the first auction has not been created,
+			// try to create a new auction.
+			creationFailed = !_createAuction();
+		} else if (hasEnded()) {
+			if (_auctionData.settled) {
+				// If the auction has ended, and is settled, try to create a new auction.
+				creationFailed = !_createAuction();
+			} else {
+				// Otherwise, if the auction has ended, but is yet been settled, settle it.
+				_settleAuction();
+				// After settling the auction, try to create a new auction.
+				if (!_createAuction()) {
+					// If the creation fails, it means that maxSupply was exceded
+					// In this case, refund all the ETH sent and early return.
+					SafeTransferLib.forceSafeTransferETH(msg.sender, msg.value);
+					return;
+				}
+			}
+		}
+		// If the auction creation fails, we must revert to prevent any bids.
+		require(!creationFailed, "Cannot create auction.");
+
+		/* --------------------- BIDDING LOGIC ---------------------- */
+
+		address lastBidder = _auctionData.bidder;
+		uint256 amount = _auctionData.amount; // `uint96`.
+		uint256 endTime = _auctionData.endTime; // `uint40`.
+
+		// Ensures that the `nftId` is equal to the auction's.
+		// This prevents the following scenarios:
+		// - A bidder bids a high price near closing time, the next auction starts,
+		//   and the high bid gets accepted as the starting bid for the next auction.
+		// - A bidder bids for the next auction due to frontend being ahead of time,
+		//   but the current auction gets extended,
+		//   and the bid gets accepted for the current auction.
+		require(nftId == _auctionData.nftId, "Bid for wrong NFT ID.");
+
+		if (amount == 0) {
+			require(msg.value >= _auctionData.reservePrice, "Bid below reserve price.");
+		} else {
+			// Won't overflow. `amount` and `bidIncrement` are both stored as 96 bits.
+			require(msg.value >= amount + _auctionData.bidIncrement, "Bid too low.");
+		}
+
+		_auctionData.bidder = msg.sender;
+		_auctionData.amount = SafeCastLib.toUint96(msg.value); // Won't overflow on ETH mainnet.
+
+		if (_auctionData.timeBuffer == 0) {
+			emit AuctionBid(nftId, msg.sender, msg.value, false);
+		} else {
+			// Extend the auction if the bid was received within `timeBuffer` of the auction end time.
+			uint256 extendedTime = block.timestamp + _auctionData.timeBuffer;
+			// Whether the current timestamp falls within the time extension buffer period.
+			bool extended = endTime < extendedTime;
+			emit AuctionBid(nftId, msg.sender, msg.value, extended);
+
+			if (extended) {
+				_auctionData.endTime = SafeCastLib.toUint40(extendedTime);
+				emit AuctionExtended(nftId, extendedTime);
+			}
+		}
+
+		if (amount != 0) {
+			// Refund the last bidder.
+			SafeTransferLib.forceSafeTransferETH(lastBidder, amount);
+		}
+	}
+
+	/**
+	* @dev Settles the auction.
+	* This method may be called by anyone if there are no bids to trigger
+	* settling the ended auction, or to settle the last auction,
+	* when all the generation hash hashes have been used.
+	 */
+	function settleAuction() external {
+		require(block.timestamp >= _auctionData.endTime, "Auction still ongoing.");
+		require(_auctionData.startTime != 0, "No auction.");
+		require(_auctionData.bidder != address(0), "No bids.");
+		require(!_auctionData.settled, "Auction already settled.");
+		_settleAuction();
+	}
+
+	/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+	/*                   ADMIN WRITE FUNCTIONS                    */
+	/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+	/**
+	 * @dev Set the auction reserve price.
+	 */
+	function setReservePrice(uint96 reservePrice) external onlyOwner {
+		_checkReservePrice(reservePrice);
+		_auctionData.reservePrice = reservePrice;
+		emit AuctionReservePriceUpdated(reservePrice);
+	}
+
+	/**
+	* @dev Set the auction bid increment.
+	*/
+	function setBidIncrement(uint96 bidIncrement) external onlyOwner {
+		_checkBidIncrement(bidIncrement);
+		_auctionData.bidIncrement = bidIncrement;
+		emit AuctionBidIncrementUpdated(bidIncrement);
+	}
+
+	/**
+	* @dev Set the auction time duration in seconds.
+	*/
+	function setDuration(uint32 duration) external onlyOwner {
+		_checkDuration(duration);
+		_auctionData.duration = duration;
+		emit AuctionDurationUpdated(duration);
+	}
+
+	/**
+	* @dev Set the auction time buffer in seconds.
+	*/
+	function setTimeBuffer(uint32 timeBuffer) external onlyOwner {
+		_auctionData.timeBuffer = timeBuffer;
+		emit AuctionTimeBufferUpdated(timeBuffer);
+	}
+
+	/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+	/*                 EVENT EMITTERS FOR TESTING                 */
+	/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+	function emitAuctionCreatedEvent(uint256 nftId, uint256 startTime, uint256 endTime)
+	external
+	onlyOwner
+	{
+		emit AuctionCreated(nftId, startTime, endTime);
+	}
+
+	function emitAuctionBidEvent(uint256 nftId, address bidder, uint256 amount, bool extended)
+	external
+	onlyOwner
+	{
+		emit AuctionBid(nftId, bidder, amount, extended);
+	}
+
+	function emitAuctionExtendedEvent(uint256 nftId, uint256 endTime) external onlyOwner {
+		emit AuctionExtended(nftId, endTime);
+	}
+
+	function emitAuctionSettledEvent(uint256 nftId, address winner, uint256 amount)
+	external
+	onlyOwner
+	{
+		emit AuctionSettled(nftId, winner, amount);
+	}
+
+	/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+	/*                 INTERNAL / PRIVATE HELPERS                 */
+	/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+	/**
+	* @dev Create an auction.
+	* Stores the auction details in the `auction` state variable
+	* and emits an `AuctionCreated` event.
+	* Returns whether the auction has been created successfully.
+	*/
+	function _createAuction() internal returns (bool) {
+		uint256 nftId = uint256(_auctionData.nftId) + 1;
+
+		if (nftId > _auctionData.maxSupply) return false;
+
+		nftId = IAuctionedNFT(_auctionData.nftContract).mint();
+
+		uint256 endTime = block.timestamp + _auctionData.duration;
+
+		_auctionData.bidder = address(1);
+		_auctionData.amount = 0;
+		_auctionData.startTime = SafeCastLib.toUint40(block.timestamp);
+		_auctionData.endTime = SafeCastLib.toUint40(endTime);
+		_auctionData.nftId = SafeCastLib.toUint24(nftId);
+		_auctionData.settled = false;
+
+		emit AuctionCreated(nftId, block.timestamp, endTime);
+
+		return true;
+	}
+
+	/**
+	 * @dev Settle an auction, finalizing the bid.
+	 */
+	function _settleAuction() internal {
+		address bidder = _auctionData.bidder;
+		uint256 amount = _auctionData.amount;
+		uint256 nftId = _auctionData.nftId;
+		address nftContract = _auctionData.nftContract;
+
+		payable(nftContract).transfer(amount);
+		IAuctionedNFT(nftContract).safeTransferFrom(
+			address(this), bidder, nftId
+		);
+
+		_auctionData.settled = true;
+
+		emit AuctionSettled(nftId, bidder, amount);
+	}
+
+	/**
+	 * @dev Checks whether `reservePrice` is greater than 0.
+	 */
+	function _checkReservePrice(uint96 reservePrice) internal pure {
+		require(reservePrice != 0, "Reserve price must be greater than 0.");
+	}
+
+	/**
+	 * @dev Checks whether `bidIncrement` is greater than 0.
+	 */
+	function _checkBidIncrement(uint96 bidIncrement) internal pure {
+		require(bidIncrement != 0, "Bid increment must be greater than 0.");
+	}
+
+	/**
+	 * @dev Checks whether `bidIncrement` is greater than 0.
+	 */
+	function _checkDuration(uint32 duration) internal pure {
+		require(duration != 0, "Duration must be greater than 0.");
+	}
+}
+
+interface IAuctionedNFT {
+
+	function safeTransferFrom(address from, address to, uint256 tokenId) external; 
+
+	/**
+	 * @dev Allows the minter to mint a NFT to itself.
+	 */
+	function mint() external returns (uint256 tokenId);
+}
+

--- a/contracts/auctionable-archetype/WeightedRewardedAuction.sol
+++ b/contracts/auctionable-archetype/WeightedRewardedAuction.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+
+import "./ScatterAuction.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "solady/src/utils/MerkleProofLib.sol";
+
+contract WeightedRewardedAuction is ScatterAuction {
+
+	/**
+	 * @dev Because solidity doesn't suppor floats, we will use
+	 * ratios as weights. This should be abstracted in the front-end
+	 * for a better UX.
+	 * @param x y Such that x/y.
+	 */
+	struct Ratio {
+		uint256 x; uint256 y;
+	}
+
+	/**
+	 * @dev Amount of eth bidded by an address.
+	 */
+	mapping(address => uint256) internal _rewardTokenShares;
+
+	/**
+	 * @dev Reward token held by this contract to redistribute
+	 * to bidders as incentive.
+	 */
+	address internal _rewardToken;
+
+	/**
+	 * @dev Contract with merkle root that holds the balance of
+	 * rewardable tokens for each bidder.
+	 */
+	address internal _rewardsBoosterStorage;
+	
+	/**
+	 * @dev Ratio of reward tokens to give a bidder for every eth
+	 * bidded. 
+	 */
+	Ratio internal _rewardRatio = Ratio(1, 1);
+	
+	/**
+	 * @dev Decimal weight for extra rewards based on rewardable
+	 * tokens held. See `rewardsBoosterStorage`. Set to (0,0)
+	 * if you want to disable extra rewards.
+	 */
+	Ratio internal _extraRewardWeighing = Ratio(0, 0);
+	
+	/**
+	 * @dev Merkle root that holds (address, rewardableTokensHeld) pairs.
+	 */
+	bytes32 public rewardableTokensHeldPerWalletRoot;
+
+
+	function createBid(uint256 nftId) override public payable {
+		super.createBid(nftId);
+		_rewardTokenShares[msg.sender] += msg.value;
+	}
+
+	function getSharesFor(address bidder) public view returns (uint256) {
+		return _rewardTokenShares[bidder];
+	}
+
+	/**
+	 * @dev Note that to implement claiming logic you need to verify
+	 * that `bidder` actually holds `uniqueDeriv`. See 
+	 * `claimRewardTokensBasedOnShares`.
+	 */
+	function getRewardsFor(address bidder, uint256 uniqueDerivsHeld) 
+		public 
+		view 
+		returns (uint256) 
+	{
+		uint256 share = _rewardTokenShares[bidder];
+		uint256 baseAmount = share * _rewardRatio.x / _rewardRatio.y;
+
+		if (!extraRewardsSupported()) return baseAmount;
+
+		return baseAmount * (
+			1 + uniqueDerivsHeld * _extraRewardWeighing.x / _extraRewardWeighing.y
+		);
+	}
+
+	function claimRewardTokensBasedOnShares(
+		bytes32[] memory proof, uint96 uniqueDerivsHeld
+	) public {
+		require(_rewardToken != address(0), "No reward token for this auction.");
+		require(_rewardTokenShares[msg.sender] > 0, "No reward tokens to claim.");
+
+		if (
+			extraRewardsSupported() &&
+			!checkBidderRewardableTokens(proof, msg.sender, uniqueDerivsHeld)
+		)
+			uniqueDerivsHeld = 0;
+		
+		IERC20 token = IERC20(_rewardToken);
+		token.transfer(msg.sender, getRewardsFor(msg.sender, uniqueDerivsHeld));
+		_rewardTokenShares[msg.sender] = 0;
+	}
+
+	function extraRewardsSupported() public view returns (bool) {
+		return _extraRewardWeighing.x != 0 && _extraRewardWeighing.y != 0;
+	}
+	
+	function checkBidderRewardableTokens(
+		bytes32[] memory proof, address bidder, uint96 rewardableTokensHeld
+	) public view returns (bool) {
+		require(rewardableTokensHeldPerWalletRoot > 0, "Merkle root not initialized.");
+		return MerkleProofLib.verify(
+			proof,
+			rewardableTokensHeldPerWalletRoot,
+			keccak256(abi.encodePacked(bidder, rewardableTokensHeld))
+		);
+	}
+	
+	/**
+	 * @dev Rewards configuration. Set `rewardToken` to `address(0)`
+	 * to disable all rewards. Set `extraRatio` to `(0,0)` to disable
+	 * all extra rewards based on the `rewardableTokensHeldRoot`.
+	 */
+	function configureRewards(
+		address rewardToken,
+		Ratio memory rewardRatio,
+		Ratio memory extraRatio,
+		bytes32 rewardableTokensHeldRoot
+	) public onlyOwner {
+		_rewardToken = rewardToken;
+		_rewardRatio = rewardRatio;
+		_extraRewardWeighing = extraRatio;
+		rewardableTokensHeldPerWalletRoot = rewardableTokensHeldRoot;
+	}
+
+	function withdrawRewardToken() public onlyOwner {
+		IERC20 token = IERC20(_rewardToken);
+		token.transfer(msg.sender, token.balanceOf(address(this)));
+	}
+}

--- a/contracts/auctionable-archetype/tokens/AuctionRewardToken.sol
+++ b/contracts/auctionable-archetype/tokens/AuctionRewardToken.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./IRewardToken.sol";
+
+contract AuctionRewardToken is ERC20, Ownable, IRewardToken {
+
+address internal _minter;
+	uint256 private _rewardRatio = 1;
+
+	constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+	function mint(address to, uint256 amount) public override onlyMinter {
+		_mint(to, amount);
+	}
+
+	function setMinter(address minter) external onlyOwner {
+		_minter = minter;
+	}
+
+	function setRewardRatio(uint256 rewardRatio) external onlyOwner {
+		_rewardRatio = rewardRatio;
+	}
+
+	/**
+	 * @dev Guards a function such that only the minter is authorized to call it.
+	 */
+	modifier onlyMinter() virtual {
+		require(msg.sender == _minter, "Unauthorized minter.");
+		_;
+	}
+
+	function getRewardRatio() external view override returns (uint256) {
+		return _rewardRatio;
+	}
+}

--- a/contracts/auctionable-archetype/tokens/AuctionableArchetype.sol
+++ b/contracts/auctionable-archetype/tokens/AuctionableArchetype.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: MIT
+// Archetype v0.5.1
+//
+//        d8888                 888               888
+//       d88888                 888               888
+//      d88P888                 888               888
+//     d88P 888 888d888 .d8888b 88888b.   .d88b.  888888 888  888 88888b.   .d88b.
+//    d88P  888 888P"  d88P"    888 "88b d8P  Y8b 888    888  888 888 "88b d8P  Y8b
+//   d88P   888 888    888      888  888 88888888 888    888  888 888  888 88888888
+//  d8888888888 888    Y88b.    888  888 Y8b.     Y88b.  Y88b 888 888 d88P Y8b.
+// d88P     888 888     "Y8888P 888  888  "Y8888   "Y888  "Y88888 88888P"   "Y8888
+//                                                            888 888
+//                                                       Y8b d88P 888
+//                                                        "Y88P"  888
+
+pragma solidity ^0.8.4;
+
+import "./AuctionableArchetypeState.sol";
+import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
+import "erc721a-upgradeable/contracts/ERC721A__Initializable.sol";
+import "../../ERC721A__OwnableUpgradeable.sol";
+import "solady/src/utils/LibString.sol";
+import "closedsea/src/OperatorFilterer.sol";
+import "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol";
+
+contract AuctionableArchetype is
+  ERC721A__Initializable,
+  ERC721AUpgradeable,
+  OperatorFilterer,
+  ERC721A__OwnableUpgradeable,
+  ERC2981Upgradeable
+{
+  //
+  // VARIABLES
+  //
+  Config public config;
+  Options public options;
+
+	string public provenance;
+	uint256 public nextTokenId;
+
+  //
+  // METHODS
+  //
+	// TODO check initialize
+  function initialize(
+    string memory name,
+    string memory symbol,
+    Config calldata config_,
+    address _receiver
+  ) external initializerERC721A {
+    __ERC721A_init(name, symbol);
+    // check max bps not reached and min platform fee.
+    if (config_.platformFee > MAXBPS || config_.platformFee < 500) {
+      revert InvalidConfig();
+		}
+
+    config = config_;
+    __Ownable_init();
+
+    if (config.ownerAltPayout != address(0)) {
+      setDefaultRoyalty(config.ownerAltPayout, config.defaultRoyalty);
+    } else {
+      setDefaultRoyalty(_receiver, config.defaultRoyalty);
+    }
+  }
+
+  //
+  // PUBLIC
+  //
+	function mint() external payable onlyAuctionHouse returns (uint256) {
+		if (options.mintLocked) revert MintEnded();
+		_mint(msg.sender, 1);
+		return _totalMinted();
+	}
+
+  function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+    if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
+
+    return
+      bytes(config.baseUri).length != 0
+        ? string(abi.encodePacked(config.baseUri, LibString.toString(tokenId)))
+        : "";
+  }
+
+	function withdraw() external {
+		uint256 platformFee = address(this).balance * config.platformFee / 10000;
+
+		if (config.superAffiliatePayout != address(0)) {
+			payable(PLATFORM).transfer(platformFee / 2);
+			payable(config.superAffiliatePayout).transfer(platformFee / 2);
+		} else {
+			payable(PLATFORM).transfer(platformFee);
+		}
+
+    if (config.ownerAltPayout != address(0)) {
+			payable(config.ownerAltPayout).transfer(address(this).balance);
+		} else {
+			payable(owner()).transfer(address(this).balance);
+		}
+	}
+
+  function platform() external pure returns (address) {
+    return PLATFORM;
+  }
+
+  //
+  // OWNER ONLY
+  //
+
+  function setBaseURI(string memory baseUri) external onlyOwner {
+    if (options.uriLocked) {
+      revert LockedForever();
+    }
+
+    config.baseUri = baseUri;
+  }
+
+  /// @notice the password is "forever"
+  function lockURI(string memory password) external onlyOwner {
+    if (keccak256(abi.encodePacked(password)) != keccak256(abi.encodePacked("forever"))) {
+      revert WrongPassword();
+    }
+
+    options.uriLocked = true;
+  }
+
+  /// @notice the password is "forever"
+  // max supply cannot subceed total supply. Be careful changing.
+  function setMaxSupply(uint32 maxSupply, string memory password) external onlyOwner {
+    if (keccak256(abi.encodePacked(password)) != keccak256(abi.encodePacked("forever"))) {
+      revert WrongPassword();
+    }
+
+    if (options.maxSupplyLocked) {
+      revert LockedForever();
+    }
+
+    if (maxSupply < _totalMinted()) {
+      revert MaxSupplyExceeded();
+    }
+
+    config.maxSupply = maxSupply;
+  }
+
+  /// @notice the password is "forever"
+  function lockMaxSupply(string memory password) external onlyOwner {
+    if (keccak256(abi.encodePacked(password)) != keccak256(abi.encodePacked("forever"))) {
+      revert WrongPassword();
+    }
+
+    options.maxSupplyLocked = true;
+  }
+
+
+  function setOwnerAltPayout(address ownerAltPayout) external onlyOwner {
+    if (options.ownerAltPayoutLocked) {
+      revert LockedForever();
+    }
+
+    config.ownerAltPayout = ownerAltPayout;
+  }
+
+  /// @notice the password is "forever"
+  function lockOwnerAltPayout(string memory password) external onlyOwner {
+    if (keccak256(abi.encodePacked(password)) != keccak256(abi.encodePacked("forever"))) {
+      revert WrongPassword();
+    }
+
+    options.ownerAltPayoutLocked = true;
+  }
+
+  function setAuctionHouse(address auctionHouse) external onlyOwner {
+    if (options.auctionHouseLocked) {
+      revert LockedForever();
+    }
+
+    config.auctionHouse = auctionHouse;
+  }
+
+  /// @notice the password is "forever"
+  function lockAuctionHouse(string memory password) external onlyOwner {
+    if (keccak256(abi.encodePacked(password)) != keccak256(abi.encodePacked("forever"))) {
+      revert WrongPassword();
+    }
+
+    options.auctionHouseLocked = true;
+  }
+
+  /// @notice the password is "forever"
+	function lockMint(string memory password) external onlyOwner {
+    if (keccak256(abi.encodePacked(password)) != keccak256(abi.encodePacked("forever"))) {
+      revert WrongPassword();
+    }
+
+		options.mintLocked = true;
+	}
+
+  //
+  // PLATFORM ONLY
+  //
+  function setSuperAffiliatePayout(address superAffiliatePayout) external onlyPlatform {
+    config.superAffiliatePayout = superAffiliatePayout;
+  }
+
+  //
+  // INTERNAL
+  //
+  function _startTokenId() internal view virtual override returns (uint256) {
+    return 1;
+  }
+
+  modifier onlyPlatform() {
+    if (msg.sender != PLATFORM) {
+      revert NotPlatform();
+    }
+    _;
+  }
+
+	modifier onlyAuctionHouse() {
+		if (msg.sender != config.auctionHouse) {
+			revert NotAuctionHouse();
+		}
+		_;
+	}
+
+  // OPTIONAL ROYALTY ENFORCEMENT WITH OPENSEA
+  function enableRoyaltyEnforcement() external onlyOwner {
+    if (options.royaltyEnforcementLocked) {
+      revert LockedForever();
+    }
+    _registerForOperatorFiltering();
+    options.royaltyEnforcementEnabled = true;
+  }
+
+  function disableRoyaltyEnforcement() external onlyOwner {
+    if (options.royaltyEnforcementLocked) {
+      revert LockedForever();
+    }
+    options.royaltyEnforcementEnabled = false;
+  }
+
+  /// @notice the password is "forever"
+  function lockRoyaltyEnforcement(string memory password) external onlyOwner {
+    if (keccak256(abi.encodePacked(password)) != keccak256(abi.encodePacked("forever"))) {
+      revert WrongPassword();
+    }
+
+    options.royaltyEnforcementLocked = true;
+  }
+
+  function setApprovalForAll(address operator, bool approved)
+    public
+    override
+    onlyAllowedOperatorApproval(operator)
+  {
+    super.setApprovalForAll(operator, approved);
+  }
+
+  function approve(address operator, uint256 tokenId)
+    public
+    payable
+    override
+    onlyAllowedOperatorApproval(operator)
+  {
+    super.approve(operator, tokenId);
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 tokenId
+  ) public payable override onlyAllowedOperator(from) {
+    super.transferFrom(from, to, tokenId);
+  }
+
+  function safeTransferFrom(
+    address from,
+    address to,
+    uint256 tokenId
+  ) public payable override onlyAllowedOperator(from) {
+    super.safeTransferFrom(from, to, tokenId);
+  }
+
+  function safeTransferFrom(
+    address from,
+    address to,
+    uint256 tokenId,
+    bytes memory data
+  ) public payable override onlyAllowedOperator(from) {
+    super.safeTransferFrom(from, to, tokenId, data);
+  }
+
+  function _operatorFilteringEnabled() internal view override returns (bool) {
+    return options.royaltyEnforcementEnabled;
+  }
+
+  //ERC2981 ROYALTY
+  function supportsInterface(bytes4 interfaceId)
+    public
+    view
+    virtual
+    override(ERC721AUpgradeable, ERC2981Upgradeable)
+    returns (bool)
+  {
+    // Supports the following `interfaceId`s:
+    // - IERC165: 0x01ffc9a7
+    // - IERC721: 0x80ac58cd
+    // - IERC721Metadata: 0x5b5e139f
+    // - IERC2981: 0x2a55205a
+    return
+      ERC721AUpgradeable.supportsInterface(interfaceId) ||
+      ERC2981Upgradeable.supportsInterface(interfaceId);
+  }
+
+  function setDefaultRoyalty(address receiver, uint16 feeNumerator) public onlyOwner {
+    config.defaultRoyalty = feeNumerator;
+    _setDefaultRoyalty(receiver, feeNumerator);
+  }
+
+	receive() external payable {}
+}

--- a/contracts/auctionable-archetype/tokens/AuctionableArchetypeState.sol
+++ b/contracts/auctionable-archetype/tokens/AuctionableArchetypeState.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// ArchetypeLogic v0.5.1
+//
+//        d8888                 888               888
+//       d88888                 888               888
+//      d88P888                 888               888
+//     d88P 888 888d888 .d8888b 88888b.   .d88b.  888888 888  888 88888b.   .d88b.
+//    d88P  888 888P"  d88P"    888 "88b d8P  Y8b 888    888  888 888 "88b d8P  Y8b
+//   d88P   888 888    888      888  888 88888888 888    888  888 888  888 88888888
+//  d8888888888 888    Y88b.    888  888 Y8b.     Y88b.  Y88b 888 888 d88P Y8b.
+// d88P     888 888     "Y8888P 888  888  "Y8888   "Y888  "Y88888 88888P"   "Y8888
+//                                                            888 888
+//                                                       Y8b d88P 888
+//                                                        "Y88P"  888
+
+pragma solidity ^0.8.4;
+
+import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "solady/src/utils/ECDSA.sol";
+
+error InvalidConfig();
+error MintEnded();
+error MaxSupplyExceeded();
+error NotTokenOwner();
+error NotPlatform();
+error WrongPassword();
+error LockedForever();
+error NotAuctionHouse();
+
+//
+// STRUCTS
+//
+
+struct Config {
+  string baseUri;
+  address ownerAltPayout; // optional alternative address for owner withdrawals.
+  address superAffiliatePayout; // optional super affiliate address, will receive half of platform fee if set.
+  uint32 maxSupply;
+  uint16 platformFee; //BPS
+  uint16 defaultRoyalty; //BPS
+  address auctionHouse;
+}
+
+struct Options {
+  bool uriLocked;
+  bool maxSupplyLocked;
+  bool ownerAltPayoutLocked;
+  bool royaltyEnforcementEnabled;
+  bool royaltyEnforcementLocked;
+  bool auctionHouseLocked;
+  bool mintLocked;
+}
+
+address constant PLATFORM = 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC; // TEST (account[2])
+// address private constant PLATFORM = 0x86B82972282Dd22348374bC63fd21620F7ED847B;
+uint16 constant MAXBPS = 5000; // max fee or discount is 50%

--- a/contracts/auctionable-archetype/tokens/IRewardToken.sol
+++ b/contracts/auctionable-archetype/tokens/IRewardToken.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IRewardToken {
+  function mint(address to, uint256 amount) external;
+	function getRewardRatio() external returns (uint256);
+}

--- a/contracts/auctionable-archetype/tokens/MinimalAuctionableNFT.sol
+++ b/contracts/auctionable-archetype/tokens/MinimalAuctionableNFT.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract MinimalAuctionableNFT is ERC721, Ownable {
+
+	address internal _minter;
+	uint32 public nextTokenId;
+
+	constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+		nextTokenId = 1;
+	}
+
+	function mint() external payable onlyMinter returns (uint256 tokenId) {
+		tokenId = nextTokenId++;
+		_mint(msg.sender, tokenId);
+	}
+
+  function setMinter(address minter) external onlyOwner {
+    _minter = minter;
+  }
+
+	/**
+	 * @dev Guards a function such that only the minter is authorized to call it.
+	 */
+	modifier onlyMinter() virtual {
+		require(msg.sender == _minter, "Unauthorized minter.");
+		_;
+	}
+
+	receive() external payable {}
+
+	function withdraw() external onlyOwner {
+		payable(msg.sender).transfer(address(this).balance);
+	}
+}


### PR DESCRIPTION
I generalized Remilias [BonklerAuction](https://bonkler.remilia.org/#home) into a more miminal and extensible auctioning system and itegrated it as I could with the Archetype contract. I have thoroughly tested the contracts using the brownie framework [in here](https://github.com/DennisDv24/scatter-auction), but they still require a review and possible refactorings.

### Architecture overview:
- `ScatterAuction.sol` is a minimal version of the original `BonklerAuction.sol` that only implements the basic logic for auctioning.
- `RewardedAuction.sol` and `WeightedRewardedAuction.sol` are `ScatterAuction.sol` extensions via inheritence that add decoupled rewarding logic based on bids.
- `MinimalAuctionableNft.sol`  is a minimal auctionable ERC721 correctly integrated with `ScatterAuction.sol`.
- `AuctionRewardToken.sol` is a minimal reward-on-bid ERC20 token correctly integrated with `RewardedAuction.sol`.
- `WeightedRewardedAuction.sol` on the other hand works with any already existing ERC20.
- `AuctionableArchetype.sol` is a `Archetype.sol` modification that works with the `WeightedRewardedAuction.sol` auctioning system. I ereased all concliting logics that would need an reimplementation.

### Deployment
I have multiple scripts on my repo showing off [how to deploy the system](https://github.com/DennisDv24/scatter-auction/blob/master/scripts/deploy_helpers.py), and I could probably work on a Factory for an easier and generalized deployment.